### PR TITLE
Provide 'max_connections' tunable in 'postgresql' chef recipe.

### DIFF
--- a/chef/cookbooks/postgresql/README.md
+++ b/chef/cookbooks/postgresql/README.md
@@ -51,6 +51,10 @@ The following attributes are generated in
 * `node['postgresql']['ssl']` - whether to enable SSL (off for version
   8.3, true for 8.4).
 
+Performance tuning attributes, each corresponds to the same-named parameter in postgresql.conf; default values listed
+
+* `node['postgresql']['tunable']['max_connections']`     = "1000"
+
 Recipes
 =======
 

--- a/chef/cookbooks/postgresql/attributes/server.rb
+++ b/chef/cookbooks/postgresql/attributes/server.rb
@@ -73,3 +73,5 @@ else
   default[:postgresql][:version] = "8.4"
   set[:postgresql][:dir]         = "/etc/postgresql/#{node[:postgresql][:version]}/main"
 end
+
+default[:postgresql][:tunable][:max_connections] = "1000"

--- a/chef/cookbooks/postgresql/metadata.rb
+++ b/chef/cookbooks/postgresql/metadata.rb
@@ -19,3 +19,12 @@ end
 end
  
 depends "openssl"
+
+attribute "postgresql/tunable",
+  :display_name => "PostgreSQL Tunables",
+  :description => "Hash of PostgreSQL tunable attributes",
+  :type => "hash"
+
+attribute "postgresql/tunable/max_connections",
+  :display_name => "PostgreSQL Tunable Max Connections",
+  :default => "1000"

--- a/chef/cookbooks/postgresql/templates/default/debian.postgresql.conf.erb
+++ b/chef/cookbooks/postgresql/templates/default/debian.postgresql.conf.erb
@@ -58,7 +58,7 @@ listen_addresses = '<%= node.postgresql.listen_addresses -%>'     # what IP addr
                     # defaults to 'localhost', '*' = all
                     # (change requires restart)
 port = 5432             # (change requires restart)
-max_connections = 100           # (change requires restart)
+max_connections = <%= node['postgresql']['tunable']['max_connections'] %>  # (change requires restart)
 # Note:  Increasing max_connections costs ~400 bytes of shared memory per 
 # connection slot, plus lock space (see max_locks_per_transaction).  You might
 # also need to raise shared_buffers to support more connections.

--- a/chef/cookbooks/postgresql/templates/default/redhat.postgresql.conf.erb
+++ b/chef/cookbooks/postgresql/templates/default/redhat.postgresql.conf.erb
@@ -61,7 +61,7 @@ listen_addresses = '<%= node.postgresql.listen_addresses -%>'         # what IP 
                                         # defaults to 'localhost', '*' = all
                                         # (change requires restart)
 #port = 5432                            # (change requires restart)
-max_connections = 100                   # (change requires restart)
+max_connections = <%= node['postgresql']['tunable']['max_connections'] %>  # (change requires restart)
 # Note:  Increasing max_connections costs ~400 bytes of shared memory per 
 # connection slot, plus lock space (see max_locks_per_transaction).
 #superuser_reserved_connections = 3     # (change requires restart)

--- a/chef/data_bags/crowbar/bc-template-database.json
+++ b/chef/data_bags/crowbar/bc-template-database.json
@@ -6,6 +6,9 @@
       "sql_engine": "postgresql",
       "mysql": {
         "datadir": "/var/lib/mysql"
+      },
+      "postgresql": {
+        "max_connections": 1000
       }
     }
   },

--- a/chef/data_bags/crowbar/bc-template-database.schema
+++ b/chef/data_bags/crowbar/bc-template-database.schema
@@ -28,7 +28,7 @@
               "type": "map",
               "required": false,
               "mapping" : {
-                "dummy": { "type": "str" }
+                "max_connections": { "type": "int" }
               }
             }
           }

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -42,6 +42,9 @@ locale_additions:
         edit_attributes:
           sql_engine: SQL Engine
           attributes: Attributes
-          mysql_datadir: MySQL Datadir
+          mysql_attributes: MySQL Attributes
+          mysql_datadir: Datadir
+          postgresql_attributes: PostgreSQL Attributes
+          postgresql_max_connections: Global Connection Limit (max_connections)
         edit_deployment:
           deployment: Deployment

--- a/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
@@ -6,27 +6,33 @@
   %div.container
     %p
       %label{ :for => :sql_engine }= t('.sql_engine')
-      = select_tag :sql_engine, options_for_select([['PostgreSQL','postgresql']], @proposal.raw_data['attributes'][@proposal.barclamp]["sql_engine"]), :onchange => "my_update_value( this.value )"
-  %div{:class => "container" , :id => "mysql_form" }
-    %label{ :for => :mysql_datadir}= t('.mysql_datadir')
-    %input#mysql_datadir{:type => "text", :name => "mysql_datadir", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["mysql"]["datadir"], :onchange => "update_value('mysql/datadir', 'mysql_datadir', 'string')"}
+      = select_tag :sql_engine, options_for_select([['PostgreSQL','postgresql']], @proposal.raw_data['attributes'][@proposal.barclamp]["sql_engine"]), :onchange => "update_value('sql_engine', 'sql_engine', 'string')"
+
+  %label.h3.mysql_engine.sql_engine{ :for => :mysql_form }= t('.mysql_attributes')
+  %div.container.mysql_engine.sql_engine{ :id => :mysql_form }
+    %p
+      %label{ :for => :mysql_datadir }= t('.mysql_datadir')
+      %input#mysql_datadir{:type => "text", :name => "mysql_datadir", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["mysql"]["datadir"], :onchange => "update_value('mysql/datadir', 'mysql_datadir', 'string')"}
+
+  %label.h3.postgresql_engine.sql_engine{ :for => :postgresql_form }= t('.postgresql_attributes')
+  %div.container.postgresql_engine.sql_engine{ :id => :postgresql_form }
+    %p
+      %label{ :for => :postgresql_max_connections }= t('.postgresql_max_connections')
+      %input#postgresql_max_connections{:type => "text", :name => "postgresql_max_connections", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["postgresql"]["max_connections"], :onchange => "update_value('postgresql/tunable/max_connections', 'postgresql_max_connections', 'string')"}
 
 
 :javascript
-  function show_form(backend) {
-    if ( backend == "mysql" ) {
-      obj1 = document.getElementById('mysql_form');
-      obj1.style.visibility = 'visible';
-    } else {
-      obj1 = document.getElementById('mysql_form');
-      obj1.style.visibility = 'hidden';
+  function toggle_sql_engine_form() {
+    $('.sql_engine').hide();
+    switch($('#sql_engine option:selected').attr('value')) {
+      case "mysql":
+        $('.mysql_engine').show();
+        break;
+      case "postgresql":
+        $('.postgresql_engine').show();
+        break;
     }
-  }
-  function my_update_value(backend) {
-    this.show_form(backend);
-    this.update_value('sql_engine', 'sql_engine', 'string');
-  }
-  $(document).ready(function(){
-    obj1 = document.getElementById('sql_engine');
-    show_form(obj1.value);
-  });
+  };
+
+  $(document).ready(function () { toggle_sql_engine_form(); });
+  $('#protocol').change(toggle_sql_engine_form);


### PR DESCRIPTION
It was also added to the Crowbar proposal, so that the value can be adjusted. This choice
should be based on the amount of (Nova) compute nodes to deploy.

Just to have this sync'ed
