### PR TITLE
Add barclamp-database to pebbles release (step one.) [1/1]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -42,3 +42,23 @@ locale_additions:
           datadir: Datadir
         edit_deployment:
           deployment: Deployment
+
+debs:
+  build_pkgs:
+    - libpq-dev
+    - postgresql-server-dev-9.1
+  pkgs:
+    # postgresql stuff
+    - postgresql
+    - postgresql-client
+rpms:
+  build_pkgs:
+    - postgresql-devel
+  pkgs:
+    # postgresql stuff
+    - postgresql-libs
+    - postgresql
+    - postgresql-server
+gems:
+  pkgs:
+    - pg


### PR DESCRIPTION
Add barclamp-database to pebbles release (step one.)

Created pebbles branch for barclamp-database. There is another pull request on master
that will need to be merged for this one - it places the barclamp-database in the openstack-os-build.

 crowbar.yml |   20 ++++++++++++++++++++
 1 file changed, 20 insertions(+)

Crowbar-Pull-ID: 9536e19de762b78b157312cf7eadbc884920a6a3

Crowbar-Release: pebbles
