### PR TITLE
Revert "Install packages with 'action :upgrade'"

### DIFF
--- a/chef/cookbooks/mysql/recipes/client.rb
+++ b/chef/cookbooks/mysql/recipes/client.rb
@@ -23,7 +23,7 @@ package "mysql-devel" do
     ["debian", "ubuntu"] => { "default" => 'libmysqlclient-dev' },
     "default" => 'libmysqlclient-dev'
   )
-  action :upgrade
+  action :install
 end
 
 package "mysql-client" do
@@ -31,7 +31,7 @@ package "mysql-client" do
     [ "centos", "redhat", "suse", "fedora"] => { "default" => "mysql" },
     "default" => "mysql-client"
   )
-  action :upgrade
+  action :install
 end
 
 if platform?(%w{debian ubuntu redhat centos fedora suse})
@@ -42,13 +42,13 @@ if platform?(%w{debian ubuntu redhat centos fedora suse})
       ["debian", "ubuntu"] => { "default" => 'libmysql-ruby' },
       "default" => 'libmysql-ruby'
     )
-    action :upgrade
+    action :install
   end
 
 else
 
   gem_package "mysql" do
-    action :upgrade
+    action :install
   end
 
 end

--- a/chef/cookbooks/mysql/recipes/python-client.rb
+++ b/chef/cookbooks/mysql/recipes/python-client.rb
@@ -19,5 +19,5 @@
 
 package "python-mysqldb" do
     package_name "python-mysql" if node.platform == "suse"
-    action :upgrade
+    action :install
 end

--- a/chef/cookbooks/mysql/recipes/server.rb
+++ b/chef/cookbooks/mysql/recipes/server.rb
@@ -59,7 +59,7 @@ end
 
 package "mysql-server" do
   package_name "mysql" if node.platform == "suse"
-  action :upgrade
+  action :install
 end
 
 service "mysql" do

--- a/chef/cookbooks/postgresql/recipes/python-client.rb
+++ b/chef/cookbooks/postgresql/recipes/python-client.rb
@@ -18,5 +18,5 @@
 #
 
 package "python-psycopg2" do
-    action :upgrade
+    action :install
 end

--- a/chef/cookbooks/postgresql/recipes/server_debian.rb
+++ b/chef/cookbooks/postgresql/recipes/server_debian.rb
@@ -28,9 +28,7 @@ else # > 8.3
   node.default[:postgresql][:ssl] = "true"
 end
  
-package "postgresql" do
-  action :upgrade
-end
+package "postgresql"
  
 service "postgresql" do
   case node['platform']

--- a/chef/cookbooks/postgresql/recipes/server_redhat.rb
+++ b/chef/cookbooks/postgresql/recipes/server_redhat.rb
@@ -52,29 +52,20 @@ package "postgresql" do
   else
     package_name "postgresql"
   end
-  action :upgrade
 end
  
 case node.platform
 when "redhat","centos","scientific"
   case
   when node.platform_version.to_f >= 6.0
-    package "postgresql-server" do
-      action :upgrade
-    end
+    package "postgresql-server"
   else
-    package "postgresql#{node['postgresql']['version'].split('.').join}-server" do
-      action :upgrade
-    end
+    package "postgresql#{node['postgresql']['version'].split('.').join}-server"
   end
 when "suse"
-  package "postgresql91-server" do
-    action :upgrade
-  end
+  package "postgresql91-server"
 when "fedora"
-  package "postgresql-server" do
-    action :upgrade
-  end
+  package "postgresql-server"
 end
  
 execute "/sbin/service postgresql initdb" do


### PR DESCRIPTION
As agreed during a community call, we want to use :install to allow
upgrades being controlled instead of automatically installed.

This reverts commit 40cc06afd8f275214547d6a0e9f8b5ae4b142fee.
