### PR TITLE
DE1357: Changing mysql attribute, Datadir, causes proposal to fail.  For 1.6 mark field as read only as changing this directory breaks mysql install on Ubuntu.  Need to fix recipe in 1.7 to take AppArmor into consideration as reconfiguring AppArmor may al

### DIFF
--- a/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
@@ -12,7 +12,7 @@
   %div.container.mysql_engine.sql_engine{ :id => :mysql_form }
     %p
       %label{ :for => :mysql_datadir }= t('.mysql_datadir')
-      %input#mysql_datadir{:type => "text", :name => "mysql_datadir", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["mysql"]["datadir"], :onchange => "update_value('mysql/datadir', 'mysql_datadir', 'string')"}
+      %input#mysql_datadir{:readonly => "readonly", :type => "text", :name => "mysql_datadir", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["mysql"]["datadir"], :onchange => "update_value('mysql/datadir', 'mysql_datadir', 'string')"}
 
   %label.h3.postgresql_engine.sql_engine{ :for => :postgresql_form }= t('.postgresql_attributes')
   %div.container.postgresql_engine.sql_engine{ :id => :postgresql_form }


### PR DESCRIPTION
 .../barclamp/database/_edit_attributes.html.haml   |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 6db80987d1d2bfc4d307061058b1a039a0d5bcfc

Crowbar-Release: mesa-1.6
