### PR TITLE
Fix incredibly small idle connection timeout in mysql. [1/1]

### DIFF
--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -54,13 +54,13 @@ default['mysql']['tunable']['thread_cache']             = "128"
 default['mysql']['tunable']['thread_cache_size']        = 8
 default['mysql']['tunable']['thread_concurrency']       = 10
 default['mysql']['tunable']['thread_stack']             = "256K"
-default['mysql']['tunable']['wait_timeout']             = "180"
+default['mysql']['tunable']['wait_timeout']             = 28800
 
 default['mysql']['tunable']['query_cache_limit']        = "1M"
 default['mysql']['tunable']['query_cache_size']         = "32M"
 
 default['mysql']['tunable']['log_slow_queries']         = "/var/log/mysql/slow.log"
-default['mysql']['tunable']['long_query_time']          = 2
+default['mysql']['tunable']['long_query_time']          = 10
 
 # InnoDB Settings
 default['mysql']['tunable']['innodb_buffer_pool_size']  = "256M"


### PR DESCRIPTION
For some reason, we were killing idle mysql connections after 180 seconds.
The default timeout for idle connections is 28800 seconds.  Switch back to that.

This should eliminate the frequent MYSQL has gone away errors we have been seeing in the logs.

 chef/cookbooks/mysql/attributes/server.rb |    4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: c136e1f6a4a9d69281ec5c30464c90b5ec27c45e

Crowbar-Release: mesa-1.6
