### PR TITLE
smoketest: Use postgresql instead of mysql on SUSE

### DIFF
--- a/smoketest/modify-json
+++ b/smoketest/modify-json
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright 2013, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+
+# use postgresql on SUSE
+if is_suse; then
+    json-edit -a attributes.database.sql_engine -v "postgresql" -
+fi


### PR DESCRIPTION
This depends on: https://github.com/crowbar/crowbar/pull/1926
