### PR TITLE
Fix for MySql configuration logs too much data

### DIFF
--- a/chef/cookbooks/mysql/attributes/server.rb
+++ b/chef/cookbooks/mysql/attributes/server.rb
@@ -60,7 +60,7 @@ default['mysql']['tunable']['query_cache_limit']        = "1M"
 default['mysql']['tunable']['query_cache_size']         = "32M"
 
 default['mysql']['tunable']['log_slow_queries']         = "/var/log/mysql/slow.log"
-default['mysql']['tunable']['long_query_time']          = 10
+default['mysql']['tunable']['long_query_time']          = 2
 
 # InnoDB Settings
 default['mysql']['tunable']['innodb_buffer_pool_size']  = "256M"

--- a/chef/cookbooks/mysql/templates/centos/my.cnf.erb
+++ b/chef/cookbooks/mysql/templates/centos/my.cnf.erb
@@ -104,7 +104,7 @@ query_cache_size        = <%= node['mysql']['tunable']['query_cache_size'] %>
 # Here you can see queries with especially long duration
 log_slow_queries        = <%= node['mysql']['tunable']['log_slow_queries'] %>
 long_query_time         = <%= node['mysql']['tunable']['long_query_time'] %>
-log-queries-not-using-indexes
+#log-queries-not-using-indexes
 
 #
 # The following can be used as easy to replay backup logs or for replication.

--- a/chef/cookbooks/mysql/templates/default/my.cnf.erb
+++ b/chef/cookbooks/mysql/templates/default/my.cnf.erb
@@ -104,7 +104,7 @@ query_cache_size        = <%= node['mysql']['tunable']['query_cache_size'] %>
 # Here you can see queries with especially long duration
 log_slow_queries        = <%= node['mysql']['tunable']['log_slow_queries'] %>
 long_query_time         = <%= node['mysql']['tunable']['long_query_time'] %>
-log-queries-not-using-indexes
+#log-queries-not-using-indexes
 
 #
 # The following can be used as easy to replay backup logs or for replication.

--- a/chef/cookbooks/mysql/templates/redhat/my.cnf.erb
+++ b/chef/cookbooks/mysql/templates/redhat/my.cnf.erb
@@ -104,7 +104,7 @@ query_cache_size        = <%= node['mysql']['tunable']['query_cache_size'] %>
 # Here you can see queries with especially long duration
 log_slow_queries        = <%= node['mysql']['tunable']['log_slow_queries'] %>
 long_query_time         = <%= node['mysql']['tunable']['long_query_time'] %>
-log-queries-not-using-indexes
+#log-queries-not-using-indexes
 
 #
 # The following can be used as easy to replay backup logs or for replication.


### PR DESCRIPTION
MySql configuration logs too much data. Fixes the performance issue. The "log-queries-not-using-indexes" flag is enabled by default configuration (/etc/mysql/my.cnf) - this results in all the fast, small queries being logged...
Huge log files (gigabytes)

 chef/cookbooks/mysql/attributes/server.rb         |    2 +-
 chef/cookbooks/mysql/templates/centos/my.cnf.erb  |    2 +-
 chef/cookbooks/mysql/templates/default/my.cnf.erb |    2 +-
 chef/cookbooks/mysql/templates/redhat/my.cnf.erb  |    2 +-
 4 files changed, 4 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: e681b7b86bbd9154fb2e085829cb29655966cd65

Crowbar-Release: roxy
