### PR TITLE
propose database for controller node

### DIFF
--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -32,9 +32,9 @@ class DatabaseService < ServiceObject
     nodes = NodeObject.all
     nodes.delete_if { |n| n.nil? or n.admin? }
     if nodes.size >= 1
-      controller = nodes.find { |n| n if n.intended_role == "controller" } || nodes.first[:fqdn]
+      controller = nodes.find { |n| n.intended_role == "controller" } || nodes.first
       base["deployment"]["database"]["elements"] = {
-        "database-server" => [ controller ]
+        "database-server" => [ controller[:fqdn] ]
       }
     end
 


### PR DESCRIPTION
Use the intended role set for the nodes to propose database deployment.
(Requires changes in barclamp-crowbar: https://github.com/crowbar/barclamp-crowbar/pull/796)
