### PR TITLE
Feature: Smoketest for MySQL and PostgreSQL

### DIFF
--- a/smoketest/00-deploy-database.test
+++ b/smoketest/00-deploy-database.test
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright 2011, Dell
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+die() {
+    res=$1
+    shift
+    echo "$@"
+    exit $res
+}
+
+echo "Finding database server..."
+db_fqdn=$(knife_node_find 'roles:database-server' FQDN)
+if [[ ! $db_fqdn ]]; then
+    die 1 "Cannot find database server"
+fi
+db_ip=$(nslookup $db_fqdn | grep Add | grep -v '#' | cut -f 2 -d ' ')
+echo "Database server IP: $db_ip"
+db_password=`knife search node 'roles:database-server' -a database.db_maker_password | grep database | awk '{print $2}'`
+db_engine=`knife search node 'roles:database-server' -a database.sql_engine | grep database | awk '{print $2}'`
+
+case $db_engine in
+mysql )
+  echo "Checking MySQL server status..."
+  ssh $db_ip "mysql -u db_maker --password=$db_password -h $db_ip -e 'CREATE DATABASE smoketest'" > /dev/null
+  status=$?
+  if [ $status -ne 0 ]; then
+    die 1 "Database query returned error code $status"
+  else
+    ssh $db_ip "mysql -u db_maker --password=$db_password -h $db_ip -e 'DROP DATABASE smoketest'" > /dev/null
+    echo "Database smoketest PASSED"
+  fi ;;
+postgresql )
+  echo "Checking PostgreSQL server status..."
+  ssh $db_ip "PGPASSWORD=$db_password psql -U db_maker -h $db_ip postgres -c 'CREATE DATABASE smoketest'" > /dev/null
+  status=$?
+  if [ $status -ne 0 ]; then
+    die 1 "Database query returned error code $status"
+  else
+    ssh $db_ip "PGPASSWORD=$db_password psql -U db_maker -h $db_ip postgres -c 'DROP DATABASE smoketest'" > /dev/null
+    echo "Database smoketest PASSED"
+  fi ;;
+esac
+
+exit 0


### PR DESCRIPTION
Smoketest for MySQL and PostgreSQL.

New feature:
- Check MySQL/PostgreSQL credentials and status by attempting create new database. For successful attempt database removed afterwards.
