### PR TITLE
Fix: Ubuntu PostgreSQL install

### DIFF
--- a/chef/cookbooks/postgresql/attributes/server.rb
+++ b/chef/cookbooks/postgresql/attributes/server.rb
@@ -74,4 +74,4 @@ else
   set[:postgresql][:dir]         = "/etc/postgresql/#{node[:postgresql][:version]}/main"
 end
 
-default[:postgresql][:tunable][:max_connections] = "1000"
+default[:postgresql][:max_connections] = "1000"

--- a/chef/cookbooks/postgresql/recipes/server_debian.rb
+++ b/chef/cookbooks/postgresql/recipes/server_debian.rb
@@ -27,30 +27,17 @@ when "8.3"
 else # > 8.3
   node.default[:postgresql][:ssl] = "true"
 end
+
+execute "tune-shmmax" do
+  command "sysctl -w kernel.shmmax=2147483648"
+  action :run
+end
  
 package "postgresql"
  
 service "postgresql" do
-  case node['platform']
-  when "ubuntu"
-    case
-    when node['platform_version'].to_f <= 10.04
-      service_name "postgresql-#{node['postgresql']['version']}"
-    else
-      service_name "postgresql"
-    end
-  when "debian"
-    case
-    when platform_version.to_f <= 5.0
-      service_name "postgresql-#{node['postgresql']['version']}"
-    when platform_version =~ /squeeze/
-      service_name "postgresql"
-    else
-      service_name "postgresql"
-    end
-  end
-  supports :restart => true, :status => true, :reload => true
-  action :nothing
+  supports :restart => true, :status => false, :reload => true
+  action [:enable, :start]
 end
  
 template "#{node[:postgresql][:dir]}/postgresql.conf" do

--- a/chef/cookbooks/postgresql/templates/default/debian.postgresql.conf.erb
+++ b/chef/cookbooks/postgresql/templates/default/debian.postgresql.conf.erb
@@ -58,7 +58,7 @@ listen_addresses = '<%= node.postgresql.listen_addresses -%>'     # what IP addr
                     # defaults to 'localhost', '*' = all
                     # (change requires restart)
 port = 5432             # (change requires restart)
-max_connections = <%= node['postgresql']['tunable']['max_connections'] %>  # (change requires restart)
+max_connections = <%= node['postgresql']['max_connections'] %>  # (change requires restart)
 # Note:  Increasing max_connections costs ~400 bytes of shared memory per 
 # connection slot, plus lock space (see max_locks_per_transaction).  You might
 # also need to raise shared_buffers to support more connections.

--- a/chef/cookbooks/postgresql/templates/default/redhat.postgresql.conf.erb
+++ b/chef/cookbooks/postgresql/templates/default/redhat.postgresql.conf.erb
@@ -61,7 +61,7 @@ listen_addresses = '<%= node.postgresql.listen_addresses -%>'         # what IP 
                                         # defaults to 'localhost', '*' = all
                                         # (change requires restart)
 #port = 5432                            # (change requires restart)
-max_connections = <%= node['postgresql']['tunable']['max_connections'] %>  # (change requires restart)
+max_connections = <%= node['postgresql']['max_connections'] %>  # (change requires restart)
 # Note:  Increasing max_connections costs ~400 bytes of shared memory per 
 # connection slot, plus lock space (see max_locks_per_transaction).
 #superuser_reserved_connections = 3     # (change requires restart)

--- a/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
@@ -18,7 +18,7 @@
   %div.section.postgresql_engine.sql_engine{ :id => :postgresql_form }
     %p
       %label{ :for => :postgresql_max_connections }= t('.postgresql_max_connections')
-      %input#postgresql_max_connections{:type => "text", :name => "postgresql_max_connections", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["postgresql"]["max_connections"], :onchange => "update_value('postgresql/tunable/max_connections', 'postgresql_max_connections', 'string')"}
+      %input#postgresql_max_connections{:type => "text", :name => "postgresql_max_connections", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["postgresql"]["max_connections"], :onchange => "update_value('postgresql/max_connections', 'postgresql_max_connections', 'integer')"}
 
 
 :javascript


### PR DESCRIPTION
Fix Ubuntu specific issues:
- Incorrect handle of service status and restart;
- Not enough memory to allocate default 1000 connections;
- Change maximal number of connections in UI doesn't change config file;
- Remove old code, which not used anymore.

To check this PR:
- Install PostgreSQL on Ubuntu;
- Change maximal number connections in UI (eg., 500);
- Make sure that PostgreSQL is running;
- Check max_connections value in config file /etc/postgresql/9.1/main/postgresql.conf. It should be the same as value in UI.
