### PR TITLE
Reverting path to the data_bag_secret in upstream cookbooks [1/1]

### DIFF
--- a/chef/cookbooks/openstack-common/attributes/default.rb
+++ b/chef/cookbooks/openstack-common/attributes/default.rb
@@ -41,7 +41,7 @@ default['openstack']['auth']['validate_certs'] = true
 # routine that looks up the value of encrypted databag values. This routine
 # uses the secret key file located at the following location to decrypt the
 # values in the data bag.
-default['openstack']['secret']['key_path'] = '/var/chef/data_bags/openstack_data_bag_secret'
+default['openstack']['secret']['key_path'] = '/etc/chef/openstack_data_bag_secret'
 
 # The name of the encrypted data bag that stores service user passwords, with
 # each key in the data bag corresponding to a named OpenStack service, like


### PR DESCRIPTION
Reverting path to the data_bag_secret in upstream cookbooks  

 .../openstack-common/attributes/default.rb         |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: e4d89d69c27d77312a94aa20a47fb0c3cf17be39

Crowbar-Release: development
