### PR TITLE
Add a helper to get the listen address of the database

### DIFF
--- a/chef/cookbooks/database/libraries/crowbar.rb
+++ b/chef/cookbooks/database/libraries/crowbar.rb
@@ -1,0 +1,5 @@
+module CrowbarDatabaseHelper
+  def self.get_listen_address(node)
+    Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+  end
+end


### PR DESCRIPTION
This will be used by other cookbooks from other barclamps to get the IP
address of the database, and this can then be changed when we add HA.
