### PR TITLE
Change log-format with date sufix

### DIFF
--- a/chef/cookbooks/postgresql/recipes/server_redhat.rb
+++ b/chef/cookbooks/postgresql/recipes/server_redhat.rb
@@ -111,3 +111,10 @@ template "#{node[:postgresql][:dir]}/postgresql.conf" do
   mode 0600
   notifies :restart, resources(:service => "postgresql")
 end
+
+template "/etc/cron.daily/postgresql-logs" do
+  source "cron-postgresql-logs.erb"
+  owner "root"
+  group "root"
+  mode 0755
+end

--- a/chef/cookbooks/postgresql/templates/default/cron-postgresql-logs.erb
+++ b/chef/cookbooks/postgresql/templates/default/cron-postgresql-logs.erb
@@ -1,0 +1,5 @@
+#!/bin/bash
+LOG_DIR=/var/lib/pgsql/data/pg_log
+AGE=2
+
+find ${LOG_DIR}/ -name "postgresql.log-*" -not -name "*bz2" -mtime +${AGE} -type f | xargs -r bzip2

--- a/chef/cookbooks/postgresql/templates/default/redhat.postgresql.conf.erb
+++ b/chef/cookbooks/postgresql/templates/default/redhat.postgresql.conf.erb
@@ -245,9 +245,9 @@ logging_collector = on                  # Enable capturing of stderr and csvlog
 # These are only used if logging_collector is on:
 log_directory = 'pg_log'                # directory where log files are written,
                                         # can be absolute or relative to PGDATA
-log_filename = 'postgresql-%a.log'      # log file name pattern,
+log_filename = 'postgresql.log-%Y%m%d%H%M'  # log file name pattern,
                                         # can include strftime() escapes
-log_truncate_on_rotation = on           # If on, an existing log file of the
+log_truncate_on_rotation = off          # If on, an existing log file of the
                                         # same name as the new log file will be
                                         # truncated rather than appended to.
                                         # But such truncation only occurs on


### PR DESCRIPTION
Currently production logs looks like follows `postgresql-<day name>.log` example postgresql-Fri.log.
This format is really bad. We should change it and add precise date when this logs were created.
Proposal is `postgresql-<day>-<month>-<year>.log` example postgresql-04-04-2014.log
