### PR TITLE
don't proceed if synchronization times out

### DIFF
--- a/chef/cookbooks/postgresql/recipes/ha.rb
+++ b/chef/cookbooks/postgresql/recipes/ha.rb
@@ -40,11 +40,13 @@ postgres_op["monitor"]["interval"] = "10s"
 # resources
 crowbar_pacemaker_sync_mark "sync-database_before_ha" do
   revision node[:database]["crowbar-revision"]
+  fatal true
 end
 
 # Avoid races when creating pacemaker resources
 crowbar_pacemaker_sync_mark "wait-database_ha_resources" do
   revision node[:database]["crowbar-revision"]
+  fatal true
 end
 
 pacemaker_primitive vip_primitive do
@@ -116,6 +118,7 @@ end
 
 crowbar_pacemaker_sync_mark "create-database_ha_resources" do
   revision node[:database]["crowbar-revision"]
+  fatal true
 end
 
 # wait for service to be active, and really ready before we go on (because we

--- a/chef/cookbooks/postgresql/recipes/ha_storage.rb
+++ b/chef/cookbooks/postgresql/recipes/ha_storage.rb
@@ -60,11 +60,13 @@ end
 # resources
 crowbar_pacemaker_sync_mark "sync-database_before_ha_storage" do
   revision node[:database]["crowbar-revision"]
+  fatal true
 end
 
 # Avoid races when creating pacemaker resources
 crowbar_pacemaker_sync_mark "wait-database_ha_storage" do
   revision node[:database]["crowbar-revision"]
+  fatal true
 end
 
 if node[:database][:ha][:storage][:mode] == "drbd"
@@ -132,6 +134,7 @@ end
 
 crowbar_pacemaker_sync_mark "create-database_ha_storage" do
   revision node[:database]["crowbar-revision"]
+  fatal true
 end
 
 # wait for fs primitive to be active, and for the directory to be actually


### PR DESCRIPTION
If we allow any of the database setup steps to be skipped on any of the nodes, then when Pacemaker attempts to start up the resources, things will fail, and we'll experience fencing.  It's more user-friendly if
the chef-client run simply fails.

This may be a contentious change, or maybe I've just misunderstood something.  But based on my testing, the status quo doesn't look right, so we at least need to discuss this :)

In fact I'm wondering if `fatal` shouldn't default to `true` - that would be safer.
