### PR TITLE
allow VIP and filesystem to start in parallel

### DIFF
--- a/chef/cookbooks/postgresql/recipes/ha.rb
+++ b/chef/cookbooks/postgresql/recipes/ha.rb
@@ -93,6 +93,7 @@ if node[:database][:ha][:storage][:mode] == "drbd"
     action :create
     # This is our last constraint, so we can finally start service_name
     notifies :run, "execute[Cleanup #{service_name} after constraints]", :immediately
+    notifies :start, "pacemaker_primitive[#{vip_primitive}]", :immediately
     notifies :start, "pacemaker_primitive[#{service_name}]", :immediately
   end
 

--- a/chef/cookbooks/postgresql/recipes/ha.rb
+++ b/chef/cookbooks/postgresql/recipes/ha.rb
@@ -83,13 +83,13 @@ if node[:database][:ha][:storage][:mode] == "drbd"
 
   pacemaker_colocation "col-#{service_name}" do
     score "inf"
-    resources [vip_primitive, fs_primitive, service_name]
+    resources "( #{vip_primitive} #{fs_primitive} ) #{service_name}"
     action :create
   end
 
   pacemaker_order "o-#{service_name}" do
     score "Mandatory"
-    ordering "#{vip_primitive} #{fs_primitive} #{service_name}"
+    ordering "( #{vip_primitive} #{fs_primitive} ) #{service_name}"
     action :create
     # This is our last constraint, so we can finally start service_name
     notifies :run, "execute[Cleanup #{service_name} after constraints]", :immediately

--- a/chef/cookbooks/postgresql/recipes/ha_storage.rb
+++ b/chef/cookbooks/postgresql/recipes/ha_storage.rb
@@ -109,7 +109,7 @@ end
 if node[:database][:ha][:storage][:mode] == "drbd"
   pacemaker_colocation "col-#{fs_primitive}" do
     score "inf"
-    resources [fs_primitive, "#{ms_name}:Master"]
+    resources "#{fs_primitive} #{ms_name}:Master"
     action :create
   end
 


### PR DESCRIPTION
Any unnecessary ordering between the VIP and filesystem resources can cause problems during the chef-client run.

This requires and is required by https://github.com/crowbar/barclamp-pacemaker/pull/92, which also requires https://github.com/crowbar/barclamp-rabbitmq/pull/35.