### PR TITLE
max_connections is an integer field, not string

### DIFF
--- a/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
@@ -17,7 +17,7 @@
         %legend
           = t('.postgresql_attributes')
 
-        = string_field %w(postgresql max_connections)
+        = integer_field %w(postgresql max_connections)
 
       -# As HA is only supported for postgresql, we put this section in #postgresql_container
       %fieldset#ha-setup{ "data-show-for-clusters-only" => "true", "data-elements-path" => "database-server" }


### PR DESCRIPTION
Currently the WebUI shows a warning complaining that e.g. 100 is not an 
integer when trying to save the proposal with a different value. So the 
max_connections attribute can not be changed.
