### PR TITLE
add our log customizations to the model

### DIFF
--- a/crowbar_framework/app/models/database_service.rb
+++ b/crowbar_framework/app/models/database_service.rb
@@ -53,6 +53,11 @@ class DatabaseService < PacemakerServiceObject
       }
     end
 
+    # archive everything rather than let logs be overwritten cyclically
+    base["attributes"]["postgresql"]["config"]["log_truncate_on_rotation"] = false
+    # linear time (as opposed to the weekday default) + more granularity
+    base["attributes"]["postgresql"]["config"]["log_filename"] = "postgresql.log-%Y%m%d%H%M"
+
     @logger.debug("Database create_proposal: exiting")
     base
   end


### PR DESCRIPTION
These changes were lost when the postgresql cookbook was updated to upstream's
version.

They originated in: https://github.com/crowbar/barclamp-database/pull/68/files
