### PR TITLE
move max_connections to postgresql.config

### DIFF
--- a/chef/data_bags/crowbar/bc-template-database.json
+++ b/chef/data_bags/crowbar/bc-template-database.json
@@ -8,7 +8,7 @@
         "datadir": "/var/lib/mysql"
       },
       "postgresql": {
-        "config_pgtune": {
+        "config": {
           "max_connections": 1000
         }
       },
@@ -31,7 +31,7 @@
     "database": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 2,
+      "schema-revision": 3,
       "element_states": {
         "database-server": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/bc-template-database.schema
+++ b/chef/data_bags/crowbar/bc-template-database.schema
@@ -28,7 +28,7 @@
               "type": "map",
               "required": false,
               "mapping": {
-                "config_pgtune": {
+                "config": {
                   "type": "map",
                   "required": false,
                   "mapping": {

--- a/chef/data_bags/crowbar/migrate/database/003_no_pgtune.rb
+++ b/chef/data_bags/crowbar/migrate/database/003_no_pgtune.rb
@@ -1,0 +1,13 @@
+def upgrade ta, td, a, d
+  a['postgresql']['config'] = {}
+  a['postgresql']['config']['max_connections'] = a['postgresql']['config_pgtune']['max_connections']
+  a['postgresql'].delete('config_pgtune')
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a['postgresql']['config_pgtune'] = {}
+  a['postgresql']['config_pgtune']['max_connections'] = a['postgresql']['config']['max_connections']
+  a['postgresql'].delete('config')
+  return a, d
+end

--- a/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/database/_edit_attributes.html.haml
@@ -17,7 +17,7 @@
         %legend
           = t('.postgresql_attributes')
 
-        = integer_field %w(postgresql config_pgtune max_connections)
+        = integer_field %w(postgresql config max_connections)
 
       -# As HA is only supported for postgresql, we put this section in #postgresql_container
       %fieldset#ha-setup{ "data-show-for-clusters-only" => "true", "data-elements-path" => "database-server" }

--- a/crowbar_framework/config/locales/database/en.yml
+++ b/crowbar_framework/config/locales/database/en.yml
@@ -27,7 +27,7 @@ en:
           datadir: 'Datadir'
         postgresql_attributes: 'PostgreSQL Options'
         postgresql:
-          config_pgtune:
+          config:
             max_connections: 'Global Connection Limit (max_connections)'
         ha_header: 'High Availability'
         ha:


### PR DESCRIPTION
Since we're not using the config_pgtune postgresql recipe, the max_connections
attribute never got used. We need to move it under 
node['postgresql']['config'] in order for the postgresql.conf template to pick
it up.
