### PR TITLE
[WIP] Only deal with pacemaker resources on the founder node (bnc#918104)

### DIFF
--- a/chef/cookbooks/postgresql/recipes/ha.rb
+++ b/chef/cookbooks/postgresql/recipes/ha.rb
@@ -54,6 +54,7 @@ pacemaker_primitive vip_primitive do
   })
   op postgres_op
   action :create
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 # We run the resource agent "ocf:heartbeat:pgsql" without params, instead of
@@ -77,6 +78,7 @@ pacemaker_primitive service_name do
   agent agent_name
   op postgres_op
   action :create
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
 if node[:database][:ha][:storage][:mode] == "drbd"
@@ -85,6 +87,7 @@ if node[:database][:ha][:storage][:mode] == "drbd"
     score "inf"
     resources [fs_primitive, vip_primitive, service_name]
     action :create
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 
   pacemaker_order "o-#{service_name}" do
@@ -94,6 +97,7 @@ if node[:database][:ha][:storage][:mode] == "drbd"
     # This is our last constraint, so we can finally start service_name
     notifies :run, "execute[Cleanup #{service_name} after constraints]", :immediately
     notifies :start, "pacemaker_primitive[#{service_name}]", :immediately
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 
   # This is needed because we don't create all the pacemaker resources in the
@@ -110,6 +114,7 @@ else
     # that they are available for the service to bind to.
     members [fs_primitive, vip_primitive, service_name]
     action [ :create, :start ]
+    only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
   end
 
 end


### PR DESCRIPTION
There's no real point in having all nodes try to update all pacemaker
resources all the time, and it actually can lead to issues due to races
when two non-founder nodes try to update the resource at the same time.

It's worth mentioning that for service LWRP, we actually want to do a
:start on each run to ensure that the service is restarted in case it
crashed. For pacemaker resources, the :start doesn't need to be done all
the time: as a crash of the service is caught by pacemaker already. So
if the founder goes missing, this won't hurt us.

http://bugzilla.suse.com/show_bug.cgi?id=918104
