### PR TITLE
Any unnecessary ordering between the VIP and filesystem resources can cause problems during the chef-client run.

### DIFF
--- a/chef/cookbooks/postgresql/recipes/ha.rb
+++ b/chef/cookbooks/postgresql/recipes/ha.rb
@@ -93,6 +93,7 @@ if node[:database][:ha][:storage][:mode] == "drbd"
     action :create
     # This is our last constraint, so we can finally start service_name
     notifies :run, "execute[Cleanup #{service_name} after constraints]", :immediately
+    notifies :start, "pacemaker_primitive[#{vip_primitive}]", :immediately
     notifies :start, "pacemaker_primitive[#{service_name}]", :immediately
   end
 

--- a/chef/cookbooks/postgresql/recipes/ha.rb
+++ b/chef/cookbooks/postgresql/recipes/ha.rb
@@ -83,13 +83,13 @@ if node[:database][:ha][:storage][:mode] == "drbd"
 
   pacemaker_colocation "col-#{service_name}" do
     score "inf"
-    resources [fs_primitive, vip_primitive, service_name]
+    resources "( #{fs_primitive} #{vip_primitive} ) #{service_name}"
     action :create
   end
 
   pacemaker_order "o-#{service_name}" do
     score "Mandatory"
-    ordering "#{fs_primitive} #{vip_primitive} #{service_name}"
+    ordering "( #{fs_primitive} #{vip_primitive} ) #{service_name}"
     action :create
     # This is our last constraint, so we can finally start service_name
     notifies :run, "execute[Cleanup #{service_name} after constraints]", :immediately

--- a/chef/cookbooks/postgresql/recipes/ha_storage.rb
+++ b/chef/cookbooks/postgresql/recipes/ha_storage.rb
@@ -137,7 +137,7 @@ end
 if node[:database][:ha][:storage][:mode] == "drbd"
   pacemaker_colocation "col-#{fs_primitive}" do
     score "inf"
-    resources [fs_primitive, "#{ms_name}:Master"]
+    resources "#{fs_primitive} #{ms_name}:Master"
     action :create
   end
 


### PR DESCRIPTION
Any unnecessary ordering between the VIP and filesystem resources can cause problems during the chef-client run.

This is a forward-port to `master` of #77 from `roxy`, and as such supercedes #77.

This requires crowbar/barclamp-pacemaker#189 (as does https://github.com/crowbar/barclamp-rabbitmq/pull/73 which is the corresponding change for rabbitmq).

This is tracked by https://trello.com/c/5SWxhpxf