### PR TITLE
[tex] Update template for /etc/sysconfig/postgresql with latest version

### DIFF
--- a/chef/cookbooks/postgresql/templates/default/pgsql.sysconfig.erb
+++ b/chef/cookbooks/postgresql/templates/default/pgsql.sysconfig.erb
@@ -1,4 +1,40 @@
-PGDATA=<%= node['postgresql']['dir'] %>
-<% if node['postgresql']['config'].attribute?("port") -%>
-PGPORT=<%= node['postgresql']['config']['port'] %>
-<% end -%>
+## Path:	   Applications/PostgreSQL
+## Description:    The PostgreSQL Database System
+## Type:	   string()
+## Default:	   "~postgres/data"
+## ServiceRestart: postgresql
+#
+# In which directory should the PostgreSQL database reside?
+#
+#POSTGRES_DATADIR="~postgres/data"
+POSTGRES_DATADIR="<%= node['postgresql']['dir'] %>"
+
+## Path:	   Applications/PostgreSQL
+## Description:    The PostgreSQL Database System
+## Type:	   string()
+## Default:        ""
+## ServiceRestart: postgresql
+#
+# The options that are given to the PostgreSQL master daemon on startup.
+# See the manual pages for postmaster and postgres for valid options.
+#
+# Don't put "-D datadir" here since it is set by the startup script
+# based on the variable POSTGRES_DATADIR above.
+#
+POSTGRES_OPTIONS=""
+
+## Path:	   Applications/PostgreSQL
+## Description:    The PostgreSQL Database System
+## Type:           string()
+## Default:        "C"
+## ServiceRestart: ""
+#
+# Specifies the locale under which the PostgreSQL database location
+# should be initialized and run. If needed, it has to be changed
+# before PostgreSQL is started for the first time. To change the
+# locale of an existsing PostgreSQL database location, it must be
+# dumped, removed and initialized from scratch using the new locale.
+#
+# If unset or empty $RC_LANG from /etc/sysconfig/language is used.
+#
+POSTGRES_LANG=""


### PR DESCRIPTION
It seems that in Postgres form version 9.1 PGDATA option is not used any more, it was replaced by POSTGRES_DATADIR. So, we would like to adopt template config for this changes.